### PR TITLE
Change fingerprint to return fingerprint of cert, not parent issuer cert.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,9 @@ Return Value:
 
 * result object with the following properties:
   * `host` - hostname of the host checked.
-  * `port` - TCP port number of the host checked,
+  * `port` - TCP port number of the host checked.
   * `valid_to` - ISO8601 timestamp string.
+  * `fingerprint` - the SHA-1 digest of the certificate as a : separated hexadecimal string.
   * `daysLeft` - how many days left until the certificate expires.
 
 Errors:

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ function checkCertExpiration(targetUrl) {
             const peerCertificate = sd.getPeerCertificate(true);
             result.valid_to = new Date(peerCertificate.valid_to).toJSON(); // ISO8601
             result.daysLeft = moment(result.valid_to, moment.ISO_8601).diff(moment(), 'days');
-            result.fingerprint = peerCertificate.issuerCertificate.fingerprint;
+            result.fingerprint = peerCertificate.fingerprint;
             sd.end();
             resolve(result);
         });

--- a/index.js
+++ b/index.js
@@ -33,8 +33,8 @@ function checkCertExpiration(targetUrl) {
         }, () => {
             const peerCertificate = sd.getPeerCertificate(true);
             result.valid_to = new Date(peerCertificate.valid_to).toJSON(); // ISO8601
-            result.daysLeft = moment(result.valid_to, moment.ISO_8601).diff(moment(), 'days');
             result.fingerprint = peerCertificate.fingerprint;
+            result.daysLeft = moment(result.valid_to, moment.ISO_8601).diff(moment(), 'days');
             sd.end();
             resolve(result);
         });


### PR DESCRIPTION
Fix for #10 

Returns the fingerprint of the cert of the host name we are checking, not the cert's issuer fingerprint.

This is useful for SAN certs with more than 1 domain per cert. The results can be grouped on fingerprint since technically they are all the same cert.

Updated readme to include fingerprint information.

I did not add fingerprint to the command line interface since I feel that info is not useful there.

Here is an example of two hostnames that are in the same cert.
![image](https://user-images.githubusercontent.com/4443025/154182684-f94878f5-7cb1-43b3-858e-6954965d6f0d.png)
